### PR TITLE
If we're already in sync, do not show output from the checkout command

### DIFF
--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -218,9 +218,9 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
     parser.add_argument('-v', '--verbose', action='count', default=0,
                         help='Output additional information to '
-                        'the screen and log file. For --status, this flag '
-                        'can be used a second time, increasing the verbosity'
-                        'level each time.')
+                        'the screen and log file. This flag can be '
+                        'used up to two times, increasing the '
+                        'verbosity level each time.')
 
     #
     # developer options

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -173,8 +173,15 @@ class _External(object):
                 self._stat.log_status_message(VERBOSITY_VERBOSE)
 
         if self._repo:
+            if self._stat.sync_state == ExternalStatus.STATUS_OK:
+                # If we're already in sync, avoid showing verbose output
+                # from the checkout command, unless the verbosity level
+                # is 2 or more.
+                checkout_verbosity = verbosity - 1
+            else:
+                checkout_verbosity = verbosity
             self._repo.checkout(self._base_dir_path,
-                                self._repo_dir_name, verbosity)
+                                self._repo_dir_name, checkout_verbosity)
 
     def checkout_externals(self, verbosity, load_all):
         """Checkout the sub-externals for this object


### PR DESCRIPTION
However, specifying '--verbose --verbose' will still show output from
the checkout command even if we're already in sync.

This implementation feels like a bit of a hack. On the other hand, I can
convince myself that it makes sense as a general rule to decrease the
verbosity level of the checkout if we're in sync.
